### PR TITLE
add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+## Global
+.DS_Store
+
+## User settings
+xcuserdata/


### PR DESCRIPTION
Hay algunos archivos de configuración que no deberían estar en el control de versiones (git) porque dependen de cómo te guste tener a ti configurado el Xcode. Los archivos del repositorio deberían ser comunes para **todos** los contribuyentes. Archivos tales como:
- Archivos de código.
- Archivos de configuración del proyecto.
- Imágenes o recursos del proyecto.
- Etc.

Este archivo es para excluir todo lo que no queremos tener en GitHub.